### PR TITLE
fix rendering on "highway=pedestrian" ways

### DIFF
--- a/layers/land.yaml
+++ b/layers/land.yaml
@@ -120,10 +120,6 @@ layers:
         squares:
             filter: { class: street_limited, type: pedestrian , $zoom: { min: 14 } }
             draw:
-                lines:
-                    color: global.square_outline_color
-                    width: function () { return 1/4 * Math.log($zoom); }
-                    order: 30
                 polygons:
                     color: global.square_color
                     order: 31


### PR DESCRIPTION
Closes: https://github.com/streetcomplete/streetcomplete-mapstyle/issues/119

as found by @Helium314 in https://github.com/streetcomplete/streetcomplete-mapstyle/issues/119#issuecomment-1120162100 and validated by @matkoniecz in https://github.com/streetcomplete/streetcomplete-mapstyle/issues/119#issuecomment-1263338424, removing those lines fixes the problematic rendering of on `highway=pedestrian` **ways**, without making **areas** problematic.

[test .apk](https://github.com/mnalis/StreetComplete/actions/runs/3229730590)  with manually modified [app/src/main/assets/map_theme/jawg/layers/land.yaml](https://github.com/mnalis/StreetComplete/commit/15477e7b835d969307e98a09731cdc1095a34c5d) compiles and works fine.

Here is example of _both_ way _and_ area for `highway=pedestrian`, before and after:

![small_Screenshot_20221011_222154_de westnordost streetcomplete](https://user-images.githubusercontent.com/156656/195205055-36b25deb-6451-48b8-9c80-a1714944a80f.jpg) ![small_Screenshot_20221011_220051_de westnordost streetcomplete mn debug2](https://user-images.githubusercontent.com/156656/195205060-f6539ef8-74c0-4334-b988-9b1648f2a761.jpg)

Confusing line in the middle of the `way` is fixed (right middle of the screenshot), while `area` on the left side is not really negatively affected.